### PR TITLE
feat: add daemon command/mode

### DIFF
--- a/src/chalk.nim
+++ b/src/chalk.nim
@@ -44,6 +44,7 @@ when isMainModule:
   of "docker":             runCmdDocker(getArgs())
   of "exec":               runCmdExec(getArgs())
   of "setup":              runCmdSetup()
+  of "daemon":             runCmdDaemon()
   of "docgen":             runChalkDocGen() # in cmd_help
   of "__.onbuild":         runCmdOnBuild() # in cmd_internal
   else:

--- a/src/commands.nim
+++ b/src/commands.nim
@@ -10,6 +10,6 @@
 
 import commands/[cmd_insert, cmd_extract, cmd_delete, cmd_docker, cmd_exec,
                  cmd_env, cmd_dump, cmd_load, cmd_version, cmd_setup, cmd_help,
-                 cmd_internal]
+                 cmd_internal, cmd_daemon]
 export cmd_insert, cmd_extract, cmd_delete, cmd_docker, cmd_exec, cmd_env,
-       cmd_dump, cmd_load, cmd_version, cmd_setup, cmd_help, cmd_internal
+       cmd_dump, cmd_load, cmd_version, cmd_setup, cmd_help, cmd_internal, cmd_daemon

--- a/src/commands/cmd_daemon.nim
+++ b/src/commands/cmd_daemon.nim
@@ -1,5 +1,5 @@
 ##
-## Copyright (c) 2023, Crash Override, Inc.
+## Copyright (c) 2024, Crash Override, Inc.
 ##
 ## This file is part of Chalk
 ## (see https://crashoverride.com/docs/chalk)

--- a/src/commands/cmd_daemon.nim
+++ b/src/commands/cmd_daemon.nim
@@ -15,14 +15,14 @@ import ".."/[config, util, reporting]
 # this const is not available in nim stdlib hence manual c import
 var TIOCNOTTY {.importc, header: "sys/ioctl.h"}: cuint
 
-proc daemon() =
+proc daemon(period: int) =
   while true:
     doReporting()
-    sleep 5000
+    sleep period
 
 proc runCmdDaemon*() =
   let
-    period = int(get[Con4mDuration](getChalkScope(), "daemon.period"))
+    period = get[int](getChalkScope(), "daemon.period")
 
   let pid = fork()
   if pid == -1:
@@ -44,4 +44,4 @@ proc runCmdDaemon*() =
       error("Error on disconnecting from tty: $1" % [$strerror(errno)])
 
   # loop forever
-  daemon()
+  daemon(period)

--- a/src/commands/cmd_daemon.nim
+++ b/src/commands/cmd_daemon.nim
@@ -1,0 +1,47 @@
+##
+## Copyright (c) 2023, Crash Override, Inc.
+##
+## This file is part of Chalk
+## (see https://crashoverride.com/docs/chalk)
+##
+
+##
+## chalk `daemon` command
+##
+
+import os, std/posix
+import ".."/[config, util, reporting]
+
+# this const is not available in nim stdlib hence manual c import
+var TIOCNOTTY {.importc, header: "sys/ioctl.h"}: cuint
+
+proc daemon() =
+  while true:
+    doReporting()
+    sleep 5000
+
+proc runCmdDaemon*() =
+  let
+    period = int(get[Con4mDuration](getChalkScope(), "daemon.period"))
+
+  let pid = fork()
+  if pid == -1:
+    error("Could not spawn daemon process.")
+    setExitCode(1)
+  if pid != 0:
+    quit()
+
+  let is_err = setpgid(0, 0)
+  if is_err == -1:
+    setExitCode(1)
+    error("Chalk couldn't reset the process group: $1" % [$strerror(errno)])
+    quit()
+
+  if isatty(0) != 0:
+    let is_err = ioctl(0, TIOCNOTTY)
+    if is_err == -1:
+      setExitCode(1)
+      error("Error on disconnecting from tty: $1" % [$strerror(errno)])
+
+  # loop forever
+  daemon()

--- a/src/con4mfuncs.nim
+++ b/src/con4mfuncs.nim
@@ -126,6 +126,14 @@ proc c4mParseJson(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
 proc dockerExe(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
   return some(pack(getDockerExeLocation()))
 
+proc c4mParseInt(args: seq[Box], unused = ConfigState(nil)): Option[Box] =
+  let
+    data = unpack[string](args[0])
+  try:
+    result = some(pack(parseInt(data)))
+  except:
+    result = none(Box)
+
 let chalkCon4mBuiltins* = [
     ("version() -> string",
      BuiltinFn(getExeVersion),
@@ -182,6 +190,11 @@ Generally, these can get very noisy, and are intended more for testing,
  debugging, etc.
 """,
      @["chalk"]),
+    ("parseInt(string) -> int",
+     BuiltinFn(c4mParseInt),
+     "Parses an int from a string",
+     @["chalk"]
+    ),
     ("command_argv() -> list[string]",
      BuiltInFn(getArgvLocal),
      """

--- a/src/configs/base_init.c4m
+++ b/src/configs/base_init.c4m
@@ -17,6 +17,8 @@ exec {
 # TODO Remove all sections below
 # Currently, these need to be here for singleton defaults to take hold.
 
+daemon { }
+
 extract { }
 
 source_marks { }

--- a/src/configs/base_outconf.c4m
+++ b/src/configs/base_outconf.c4m
@@ -35,6 +35,10 @@ outconf heartbeat {
   report_template:        "report_default"
 }
 
+outconf daemon {
+  report_template:        "report_default"
+}
+
 outconf delete {
   report_template:        "report_default"
 }

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -13,7 +13,7 @@ default_key_priority := 4611686018427387904  # 2^62.
 # These are the valid command-line commands.
 valid_chalk_cmds     := ["help", "insert", "extract", "delete", "config",
                          "load", "dump", "docker", "version", "env", "exec",
-                         "setup", "docgen", "__"]
+                         "daemon", "setup", "docgen", "__"]
 
 all_cmds_that_insert := ["insert", "build", "push", "load", "setup"]
 
@@ -2197,6 +2197,23 @@ final report, if the monitored process has exited.
   }
 }
 
+singleton daemon {
+  gen_fieldname: "daemonConfig"
+  gen_typename:  "DaemonConfig"
+  gen_setters:   false
+  user_def_ok:   false
+
+  field period {
+    type:  Duration
+    default: << 5 seconds >>
+    shortdoc: "How often the daemon should wake and process"
+    doc: """
+The chalk daemon will sleep for this amount of time before reporting on the host
+"""
+
+  }
+}
+
 singleton env_config {
   gen_fieldname: "envConfig"
   gen_typename:  "EnvConfig"
@@ -2624,6 +2641,7 @@ root {
   allow extract
   allow docker
   allow exec
+  allow daemon
   allow load
   allow env_config
   allow source_marks

--- a/src/configs/chalk.c42spec
+++ b/src/configs/chalk.c42spec
@@ -2204,9 +2204,9 @@ singleton daemon {
   user_def_ok:   false
 
   field period {
-    type:  Duration
-    default: << 5 seconds >>
-    shortdoc: "How often the daemon should wake and process"
+    type: int
+    default: 5000
+    shortdoc: "How often the daemon should wake and process in milliseconds"
     doc: """
 The chalk daemon will sleep for this amount of time before reporting on the host
 """

--- a/src/configs/getopts.c4m
+++ b/src/configs/getopts.c4m
@@ -486,6 +486,12 @@ The named reporting template must already exist in your configuration.
 """
     }
   }
+
+  command daemon {
+    aliases: []
+    shortdoc: "Run in daemon mode"
+  }
+
   command config {
     aliases:  []
     shortdoc: "Show configuration variables and settings"

--- a/src/configs/getopts.c4m
+++ b/src/configs/getopts.c4m
@@ -489,7 +489,16 @@ The named reporting template must already exist in your configuration.
 
   command daemon {
     aliases: []
+    args: (0, high())
     shortdoc: "Run in daemon mode"
+
+    flag_arg period {
+      aliases: ["p"]
+      callback: func set_daemon_period
+      doc: """
+How long the daemon will sleep before submitting a new report in milliseconds
+"""
+      }
   }
 
   command config {
@@ -791,4 +800,13 @@ func set_artifact_search_path(args: list[string]) {
 
 func on_conf_load(args: list[string]) {
   add_override("artifact_search_path", [program_path() + "/" + program_name()])
+}
+
+func set_daemon_period(period: string) {
+  val := parseInt(period)
+  if val > 0 {
+      add_override("daemon.period", val)
+      return ""
+  }
+  return "Not a valid argument for period"
 }


### PR DESCRIPTION
Adds a new base command; daemon
Allows chalk to report over time (similar to exec) but without requiring a binary for chalk to exec

Currently very slim but can be used as a jumping point to add c&c for other chalk instances

<!-- Please ensure you have done the following steps: -->

- [ ] Followed the steps in the contributor's guide: https://crashoverride.com/docs/other/contributing#filing-the-pull-request
- [ ] PR title uses [semantic commit messages](https://nitayneeman.com/posts/understanding-semantic-commit-messages-using-git-and-angular/#fix)
- [ ] Filled out the template to a useful degree
- [ ] Updated `CHANGELOG.md` if necessary

## Issue

<!-- Link the ticket(s) that this PR works on. Every pr should have a linked issue. -->

## Description

<!-- What does this PR do? A list of changes would be useful for larger PRs. -->

## Testing

<!-- What are the steps needed to test this PR? -->
